### PR TITLE
Fix ReferenceError of querystring module

### DIFF
--- a/src/lib/qingcloud.coffee
+++ b/src/lib/qingcloud.coffee
@@ -1,5 +1,6 @@
 extend = require 'extend'
 request = require 'request'
+querystring = require 'querystring'
 
 util = require './util'
 config = require '../config'


### PR DESCRIPTION
This simple patch will fix the error below:

`ReferenceError: querystring is not defined`

Thanks.